### PR TITLE
Adding certs into container to make https call available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+FROM alpine:latest as cert
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+
 FROM scratch
+COPY --from=cert /etc/ssl /etc/ssl
 COPY api-scenario /
+WORKDIR scenario
 ENTRYPOINT ["/api-scenario"]


### PR DESCRIPTION
# Description
We cannot call an http endpoint in the docker image because there is no `ca-certificates` available in the container `scratch`.

This PR adds the `ca-certificates` from the lastest `alpine` in the `scratch` container. 

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Closes issue(s)
Resolve #51 

# Checklist
- [x] I have tested this code
- [ ] I have added unit test to cover this code
- [ ] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
