### PR TITLE
#17 support variable in value of assertion

### DIFF
--- a/pkg/controller/assertion_ctrl.go
+++ b/pkg/controller/assertion_ctrl.go
@@ -27,15 +27,11 @@ func NewAssertionController() AssertionController {
 
 const ComparisonNotSupportedMessage = "the comparison %s was not supported for the source"
 
-
-func (ctrl *assertionControllerImpl) patchAssertion(assertion model.Assertion) model.Assertion {
-	assertion.Value = context.GetContext().Patch(assertion.Value)
-	return assertion
-}
-
 // Assert is testing an assertion on a API response.
 func (ctrl *assertionControllerImpl) Assert(assertion model.Assertion, resp model.Response) model.ResultAssertion {
+
 	assertion = ctrl.patchAssertion(assertion)
+
 	switch assertion.Source {
 	case model.ResponseStatus:
 		res := ctrl.assertNumber(assertion, float64(resp.StatusCode))
@@ -410,4 +406,10 @@ func (ctrl *assertionControllerImpl) assertMap(assertion model.Assertion, apiVal
 		message := fmt.Sprintf(ComparisonNotSupportedMessage, comparison)
 		return model.ResultAssertion{Success: false, Message: message, Err: errors.New(message)}
 	}
+}
+
+// patchAssertion patch the value of the assertion if there is a variable in it.
+func (ctrl *assertionControllerImpl) patchAssertion(assertion model.Assertion) model.Assertion {
+	assertion.Value = context.GetContext().Patch(assertion.Value)
+	return assertion
 }

--- a/pkg/controller/assertion_ctrl.go
+++ b/pkg/controller/assertion_ctrl.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/jmoiron/jsonq"
+	"github.com/thomaspoignant/api-scenario/pkg/context"
 	"github.com/thomaspoignant/api-scenario/pkg/model"
 	"github.com/thomaspoignant/api-scenario/pkg/util"
 	"net/http"
@@ -26,9 +27,15 @@ func NewAssertionController() AssertionController {
 
 const ComparisonNotSupportedMessage = "the comparison %s was not supported for the source"
 
+
+func (ctrl *assertionControllerImpl) patchAssertion(assertion model.Assertion) model.Assertion {
+	assertion.Value = context.GetContext().Patch(assertion.Value)
+	return assertion
+}
+
 // Assert is testing an assertion on a API response.
 func (ctrl *assertionControllerImpl) Assert(assertion model.Assertion, resp model.Response) model.ResultAssertion {
-
+	assertion = ctrl.patchAssertion(assertion)
 	switch assertion.Source {
 	case model.ResponseStatus:
 		res := ctrl.assertNumber(assertion, float64(resp.StatusCode))

--- a/pkg/controller/assertion_ctrl_test.go
+++ b/pkg/controller/assertion_ctrl_test.go
@@ -2,6 +2,7 @@ package controller_test
 
 import (
 	"fmt"
+	"github.com/thomaspoignant/api-scenario/pkg/context"
 	"github.com/thomaspoignant/api-scenario/pkg/controller"
 	"github.com/thomaspoignant/api-scenario/pkg/model"
 	"github.com/thomaspoignant/api-scenario/test"
@@ -1224,6 +1225,21 @@ func TestResponseJsonInvalidJson(t *testing.T) {
 		success:  false,
 		err:      true,
 	})
+}
+
+func TestVariableInAssertion(t *testing.T) {
+	context.GetContext().ResetContext()
+	context.GetContext().Add("name", "Anidter")
+
+	assertion := model.Assertion{Comparison: model.Equal, Value: "{{name}}", Property: "name.familyName", Source: model.ResponseJson}
+	te(t, assertion, response, expectedResult{
+		source:   model.ResponseJson,
+		message:  "'Anidter' was equal to Anidter",
+		property: assertion.Property,
+		success:  true,
+		err:      false,
+	})
+	context.GetContext().ResetContext()
 }
 
 // response_header


### PR DESCRIPTION
# Description
It was not possible to have an assertion with variables in `value`.

With this PR you can have this kind of assertion:
```json
{
  "comparison": "equal",
  "property": "name.familyName",
   "value": "{{randomFamilyName}}",
   "source": "response_json"
}
```

# Changes include
- [x] New feature (non-breaking change that adds functionality)

# Closes issue(s)
Resolve #17

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
