### PR TITLE
#57 Allow not_empty on bool property

### DIFF
--- a/pkg/controller/assertion_ctrl_test.go
+++ b/pkg/controller/assertion_ctrl_test.go
@@ -971,6 +971,17 @@ func TestResponseJsonNotEqualsBoolValid(t *testing.T) {
 	})
 }
 
+func TestResponseJsonNotEqualsBoolErr(t *testing.T) {
+	assertion := model.Assertion{Comparison: model.NotEqual, Value: "tru", Property: "active", Source: model.ResponseJson}
+	te(t, assertion, response, expectedResult{
+		source:   model.ResponseJson,
+		message:  "'tru' was not comparable with a boolean value true",
+		property: assertion.Property,
+		success:  false,
+		err:      true,
+	})
+}
+
 func TestResponseJsonNotEmptyBoolValid(t *testing.T) {
 	assertion := model.Assertion{Comparison: model.NotEmpty, Property: "active", Source: model.ResponseJson}
 	te(t, assertion, response, expectedResult{

--- a/pkg/controller/assertion_ctrl_test.go
+++ b/pkg/controller/assertion_ctrl_test.go
@@ -971,6 +971,17 @@ func TestResponseJsonNotEqualsBoolValid(t *testing.T) {
 	})
 }
 
+func TestResponseJsonNotEmptyBoolValid(t *testing.T) {
+	assertion := model.Assertion{Comparison: model.NotEmpty, Property: "active", Source: model.ResponseJson}
+	te(t, assertion, response, expectedResult{
+		source:   model.ResponseJson,
+		message:  "'active' was not empty",
+		property: assertion.Property,
+		success:  true,
+		err:      false,
+	})
+}
+
 func TestResponseJsonEqualsBoolValid(t *testing.T) {
 	assertion := model.Assertion{Comparison: model.Equal, Value: "true", Property: "active", Source: model.ResponseJson}
 	te(t, assertion, response, expectedResult{

--- a/pkg/util/bool_util.go
+++ b/pkg/util/bool_util.go
@@ -1,0 +1,17 @@
+package util
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// CompareBool checks if the value as string is equals to expected value.
+func CompareBool(expected bool, value string) (bool, error) {
+
+	testValue, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("'%s' was not comparable with a boolean value %t", value, expected)
+	}
+
+	return testValue == expected, nil
+}

--- a/pkg/util/bool_util_test.go
+++ b/pkg/util/bool_util_test.go
@@ -1,0 +1,53 @@
+package util
+
+import "testing"
+
+func TestCompareBool(t *testing.T) {
+	type args struct {
+		expected bool
+		value    string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{ name: "Valid bool should return true",
+			args: args{
+				expected: true,
+				value: "true",
+			},
+			want: true,
+			wantErr: false,
+		},
+		{ name: "Valid bool should return false",
+			args: args{
+				expected: true,
+				value: "false",
+			},
+			want: false,
+			wantErr: false,
+		},
+		{ name: "Should return an error",
+			args: args{
+				expected: true,
+				value: "fals",
+			},
+			want: false,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := CompareBool(tt.args.expected, tt.args.value)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("CompareBool() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("CompareBool() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Description
`not_empty` was not working for `bool` property, this PR allows it.

# Changes include
- [x] Bugfix (non-breaking change that solves an issue)

# Closes issue(s)
<!-- 
Please add the id of the issue this pull request is resolving.
We try to have an issue for every PR it is easier to talk about the feature/fix that way.
-->
Resolve #57 

# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
