### PR TITLE
Rename properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Assertions are a big part of api-scenario, this is the acceptance tests of your 
 |**equals** 	    |`equal`                     |A string comparison of the actual and expected value. Non-string values are cast to a string before comparing. For comparing non-integer numbers, use equals (number).
 |**does not equal** |`not_equal`                 |A string comparison of the actual and target value.
 |**contains** 	    |`contains`                  |The actual value contains the target value as a substring.
-|**does not contain** 	|`does_not_contains`     |The target value is not found within the actual value.
+|**does not contain** 	|`does_not_contain`      |The target value is not found within the actual value.
 |**has key**        |`has_key`                   |Checks for the existence of the expected value within a dictionary's keys. The actual value must point to a dictionary **(JSON only)**.
 |**has value** 	    |`has_value`                 |Checks a list or dictionary for the existence of the expected value in any of the list or dictionary values. The actual value must point to a JSON list or dictionary **(JSON only)**.
 |**is null**        |`is_null`                   |Checks that a value for a given JSON key is null.

--- a/pkg/model/comparison.go
+++ b/pkg/model/comparison.go
@@ -13,7 +13,7 @@ const (
 	IsGreaterThan                          //is_greater_than
 	IsGreaterThanOrEqual                   //is_greater_than_or_equal
 	Contains                               //contains
-	DoesNotContain                         //does_not_contains
+	DoesNotContain                         //does_not_contain
 	NotEmpty                               //not_empty
 	Empty                                  //empty
 	IsNull                                 //is_null

--- a/pkg/model/step.go
+++ b/pkg/model/step.go
@@ -7,7 +7,7 @@ type Step struct {
 
 	Headers    map[string][]string `json:"headers,omitempty"`
 	Assertions []Assertion         `json:"assertions,omitempty"`
-	Method     string              `json:"Method,omitempty"`
+	Method     string              `json:"method,omitempty"`
 	Duration   int                 `json:"duration,omitempty"`
 	Body       string              `json:"body,omitempty"`
 }


### PR DESCRIPTION
# Description
- Rename the property does not contain `does_not_contains` -> `does_not_contain`.
  - There is a breaking change, but the naming is better without the `s`.
- Rename the property `Method` -> `method`.
  - All the test scenario are already written with the lowercase syntax.



# Changes include
- [x] Bugfix (non-breaking change that solves an issue)
- [x] Breaking changes (change that is not backward-comptible and/or changes current functionality)



# Checklist
- [x] I have tested this code
- [x] I have added unit test to cover this code
- [x] I have updated the Readme
- [x] I have followed the [contributing guide](CONTRIBUTING.md)
